### PR TITLE
Feat/registry base

### DIFF
--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -1,0 +1,23 @@
+#include "buttons.h"
+
+/* Bind Input */
+void bindInput() {
+    /* BUTTONS */
+    Input::bindKeyToButton(BUTTON_JUMP, GLFW_KEY_SPACE);
+    Input::bindMouseToButton(BUTTON_FIRE, GLFW_MOUSE_BUTTON_1);
+
+    /* AXIS */
+    Input::initAxis(AXIS_LOOK_VERTICAL, 0);
+    Input::bindKeysToAxis(AXIS_LOOK_VERTICAL, GLFW_KEY_I, GLFW_KEY_K, 0.5);
+    Input::bindMouseYToAxis(AXIS_LOOK_VERTICAL, 0.1, false);
+
+    Input::initAxis(AXIS_LOOK_HORIZONTAL, 0);
+    Input::bindKeysToAxis(AXIS_LOOK_HORIZONTAL, GLFW_KEY_L, GLFW_KEY_J, 0.5);
+    Input::bindMouseXToAxis(AXIS_LOOK_HORIZONTAL, 0.1, false);
+
+    Input::initAxis(AXIS_FORWARD, 1.0);
+    Input::bindKeysToAxis(AXIS_FORWARD, GLFW_KEY_W, GLFW_KEY_S);
+
+    Input::initAxis(AXIS_STRAFE, 1.0);
+    Input::bindKeysToAxis(AXIS_STRAFE, GLFW_KEY_D, GLFW_KEY_A);
+}

--- a/src/buttons.h
+++ b/src/buttons.h
@@ -10,25 +10,3 @@
 #define AXIS_LOOK_HORIZONTAL 102
 #define AXIS_FORWARD 103
 #define AXIS_STRAFE 104
-
-/* Bind Input */
-void bindInput() {
-    /* BUTTONS */
-    Input::bindKeyToButton(BUTTON_JUMP, GLFW_KEY_SPACE);
-    Input::bindMouseToButton(BUTTON_FIRE, GLFW_MOUSE_BUTTON_1);
-
-    /* AXIS */
-    Input::initAxis(AXIS_LOOK_VERTICAL, 0);
-    Input::bindKeysToAxis(AXIS_LOOK_VERTICAL, GLFW_KEY_I, GLFW_KEY_K, 0.5);
-    Input::bindMouseYToAxis(AXIS_LOOK_VERTICAL, 0.1, false);
-
-    Input::initAxis(AXIS_LOOK_HORIZONTAL, 0);
-    Input::bindKeysToAxis(AXIS_LOOK_HORIZONTAL, GLFW_KEY_L, GLFW_KEY_J, 0.5);
-    Input::bindMouseXToAxis(AXIS_LOOK_HORIZONTAL, 0.1, false);
-
-    Input::initAxis(AXIS_FORWARD, 1.0);
-    Input::bindKeysToAxis(AXIS_FORWARD, GLFW_KEY_W, GLFW_KEY_S);
-
-    Input::initAxis(AXIS_STRAFE, 1.0);
-    Input::bindKeysToAxis(AXIS_STRAFE, GLFW_KEY_D, GLFW_KEY_A);
-}

--- a/src/fileloader.cpp
+++ b/src/fileloader.cpp
@@ -1,11 +1,11 @@
 #include "fileloader.h"
 
-std::string FileLoader::loadText(std::string path) {
+std::string FileLoader::loadText(std::string const& path) {
     std::ifstream stream(path);
     std::string str;
 
     if (!stream) {
-        std::cout << "Could not open file: \"" << path << "\"" << std::endl;
+        std::cerr << "Could not open file: \"" << path << "\"" << std::endl;
         throw -1;
     }
 

--- a/src/fileloader.h
+++ b/src/fileloader.h
@@ -6,5 +6,5 @@
 class FileLoader {
    public:
     // Load ascii text from file
-    static std::string loadText(std::string path);
+    static std::string loadText(std::string const& path);
 };

--- a/src/registries.cpp
+++ b/src/registries.cpp
@@ -1,0 +1,8 @@
+#include "registries.h"
+
+/* -- Register Shader Programs -- */
+
+//void initShaderPrograms(Registry<ShaderProgram> *reg) {}
+
+/* -- Registry Instantiations -- */
+//Registry<ShaderProgram> const REG::SHADER_PROGRAMS(initShaderPrograms);

--- a/src/registries.h
+++ b/src/registries.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "registry.h"
+
+/* -- Registry Declarations -- */
+
+class REG {
+   public:
+    //static Registry<ShaderProgram> const SHADER_PROGRAMS;
+};

--- a/src/registry.h
+++ b/src/registry.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <iostream>
+#include <map>
+
+#include "buttons.h"
+
+template <typename T>
+class Registry {
+   public:
+    // The class may only be instantiated by friends
+    Registry<T>() = delete;
+
+    // Puts a value into the registry
+    Registry<T>* put(std::string const& name, T* val) {
+        if (_bank.count(name)) {
+            std::cerr << "There is already an entry with name \"" << name << "\" in this registry" << std::endl;
+            throw -1;
+        }
+
+        _bank[name] = val;
+        return this;
+    }
+
+    // Fetches the entry with the specified name from the registry (returns 'nullptr' if there is no match)
+    T* get(std::string const& name) const {
+        if (!_bank.count(name))
+            return nullptr;
+
+        return _bank.at(name);
+    }
+
+   private:
+    // The passed function will be called with this registry, and is supposed to populate it.
+    Registry<T>(void (*init)(Registry<T>*)) {
+        init(this);
+    }
+
+    // Delete values from registry
+    ~Registry<T>() {
+        for (auto&& v : _bank)
+            delete v.second;
+    }
+
+    // Registry container
+    std::map<std::string, T*> _bank;
+
+    // May only be instantiated by class REG in 'registries.h'
+    friend class REG;
+};


### PR DESCRIPTION
Implemented a `Registry<T>` class in `registry.h`, which should be used for all registries. Registries are to be declared in the static class `REG` found in `registries.h`. Registration functions should be put into `registries.cpp`, together with instantiations of the `REG` members.

Several minor issues were fixed as well. The biggest issues was that `buttons.h` couldn't be included from more than one `.cpp` file without linking errors.

Closes #24 