### PR TITLE
feat: room class

### DIFF
--- a/src/entity.h
+++ b/src/entity.h
@@ -9,7 +9,11 @@
 #include <vector>
 
 #include "component.h"
+#include "room.h"
 #include "transform.h"
+
+// Forward declaration
+class Room;
 
 class Entity {
    public:
@@ -35,7 +39,9 @@ class Entity {
     std::vector<T*> getComponents();
 
     /* -- Room -- */
-    //Room* getRoom();
+
+    // Returns the room of this entity (or nullptr if there is no room)
+    inline Room* getRoom() { return _parent == nullptr ? _room : _parent->getRoom(); }
 
     /* -- Transform -- */
     inline Transform* getTransform() { return &_transform; }
@@ -43,10 +49,13 @@ class Entity {
     glm::mat4 getGlobalTransformMatrix();
 
    private:
+    Room* _room{nullptr};
     std::vector<Entity*> _children;
     std::vector<Component*> _components;
     Entity* _parent{nullptr};
     Transform _transform;
+
+    friend class Room;
 };
 
 #include "entity.tcc"

--- a/src/room.cpp
+++ b/src/room.cpp
@@ -1,0 +1,85 @@
+#include "room.h"
+
+void Room::update(double const& dt) {
+    for (auto&& e : _entities)
+        e.second->update(dt);
+}
+
+void Room::render(glm::mat4 const& m) {
+    for (auto&& e : _entities)
+        e.second->render(m);
+}
+
+Room* Room::addEntity(std::string const& tag, Entity* e) {
+    if (_entities.count(tag)) {
+        std::cerr << "There is already an entity with tag \"" << tag << "\"" << std::endl;
+        throw -1;
+    }
+
+    if (e->getRoom() != nullptr) {
+        std::cerr << "The entity is already in another room" << std::endl;
+        throw -1;
+    }
+
+    e->_room = this;
+    _entities.emplace(tag, e);
+
+    return this;
+}
+
+Room* Room::addEntities(std::map<std::string, Entity*> const& m) {
+    for (auto&& e : m)
+        addEntity(e.first, e.second);
+    return this;
+}
+
+Entity* Room::transferEntity(std::string const& tag, Room* target, std::string const& newTag) {
+    if (!hasEntity(tag) || target->hasEntity(tag)) {
+        std::cerr << "Could not transfer entity with tag \"" << tag << "\"" << std::endl;
+        throw -1;
+    }
+
+    Entity* e = removeEntity(tag);
+    target->addEntity(newTag.empty() ? tag : newTag, e);
+
+    return e;
+}
+
+Entity* Room::retrieveEntity(std::string const& tag, Room* from, std::string const& newTag) {
+    if (hasEntity(tag) || !from->hasEntity(tag)) {
+        std::cerr << "Could not retrieve entity with tag \"" << tag << "\"" << std::endl;
+        throw -1;
+    }
+
+    Entity* e = from->removeEntity(tag);
+    addEntity(newTag.empty() ? tag : newTag, e);
+
+    return e;
+}
+
+Entity* Room::removeEntity(std::string const& tag) {
+    Entity* e = _entities.at(tag);
+    _entities.erase(tag);
+    e->_room = nullptr;
+    return e;
+}
+
+std::string Room::getTag(Entity* e) {
+    auto it = std::find_if(_entities.begin(), _entities.end(), [e](auto&& p) {
+        return p.second == e;
+    });
+
+    if (it == _entities.end()) {
+        std::cerr << "The specified entity does not exist in this room" << std::endl;
+        throw -1;
+    }
+
+    return it->first;
+}
+
+Room::~Room() {
+    for (auto&& e : _entities)
+        delete e.second;
+
+    _entities.clear();
+}

--- a/src/room.h
+++ b/src/room.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+#include "entity.h"
+
+typedef size_t RoomID;
+
+class Room {
+   public:
+    Room() = delete;
+    Room(RoomID id) : _id{id} {};
+    ~Room();
+
+    void update(double const& dt);
+    void render(glm::mat4 const& m);
+
+    Room* addEntity(std::string const& tag, Entity* e);
+    Room* addEntities(std::map<std::string, Entity*> const& m);
+
+    Entity* transferEntity(std::string const& tag, Room* target, std::string const& newTag = "");
+    Entity* retrieveEntity(std::string const& tag, Room* from, std::string const& newTag = "");
+
+    // Make sure to delete the entity if it is no longer needed
+    Entity* removeEntity(std::string const& tag);
+
+    inline RoomID getID() { return _id; }
+
+    std::string getTag(Entity* e);
+    inline bool hasEntity(std::string const& tag) { return _entities.count(tag); }
+    inline Entity* getEntity(std::string const& tag) { return _entities.at(tag); }
+    inline std::map<std::string, Entity*> getEntities() { return _entities; }
+
+   private:
+    RoomID _id;
+    std::map<std::string, Entity*> _entities;
+};


### PR DESCRIPTION
Implemented a `Room` class. The class is used to manage entities, and may be rendered or updated, meaning that those functions are called for all entities respectively. Entities are aware of what room they're in.

Closes #4 