### PR TITLE
Feat/shader program lighting

### DIFF
--- a/res/shader/test.frag
+++ b/res/shader/test.frag
@@ -2,7 +2,7 @@
 
 out vec4 out_Color;
 
-in vec3 pass_Color;
+in vec4 pass_Color;
 void main() {
-    out_Color = vec4(pass_Color, 1.0);
+    out_Color = pass_Color;
 }

--- a/res/shader/test.vert
+++ b/res/shader/test.vert
@@ -1,11 +1,23 @@
 #version 430
 
+// Uniform matrices
+layout(location=0) uniform mat4 modelViewMat;
+layout(location=1) uniform mat4 projectionMat;
+
+// Uniform lighting
+layout(location=1000) uniform uint nrLights;
+layout(location=1032) uniform uint lightTypes[32];
+layout(location=1064) uniform vec3 lightPositions[32];
+layout(location=1096) uniform vec3 lightColors[32];
+layout(location=1128) uniform double lightRanges[32];
+
+// Attributes
 layout(location=0) in vec3 in_Position;
-in vec3 in_Color;
+layout(location=1) in vec3 in_Normal;
+layout(location=2) in vec3 in_TexCoords;
 
-out vec3 pass_Color;
+out vec4 pass_Color;
 void main() {
-    gl_Position = vec4(in_Position, 1.0);
-
-    pass_Color = in_Color;
+    gl_Position = vec4(in_Position + lightPositions[0], 1.0);
+    pass_Color = vec4(lightColors[0], lightRanges[0]);
 }

--- a/src/components/material.h
+++ b/src/components/material.h
@@ -17,6 +17,8 @@ class Material : public Component {
 
     void update(double const &dt) override {}
     void render(glm::mat4 const &m) override {}
+    void enterRoom(Room *newRoom) override {}
+    void exitRoom(Room *oldRoom) override {}
     void attach() override {}
     void detach() override {}
 

--- a/src/components/pointlight.h
+++ b/src/components/pointlight.h
@@ -6,8 +6,8 @@
 namespace COMP {
 class PointLight : public Component {
    public:
-    PointLight(glm::vec3 const& color)
-        : color{color} {}
+    PointLight(glm::vec3 const& color, double range = 5.0)
+        : color{color}, range{range} {}
 
     void update(double const& dt) override {}
     void render(glm::mat4 const& m) override {}
@@ -22,6 +22,11 @@ class PointLight : public Component {
         oldRoom->_removeLight(this);
     }
 
+    inline glm::vec3 position() {
+        return glm::vec3(_parent->getGlobalTransformMatrix() * glm::vec4{0.0, 0.0, 0.0, 1.0});
+    }
+
     glm::vec3 color;
+    double range;
 };
 }  // namespace COMP

--- a/src/shaderprogram.cpp
+++ b/src/shaderprogram.cpp
@@ -42,6 +42,19 @@ ShaderProgram* ShaderProgram::sendLights(std::vector<Component*> const& lights,
     return this;
 }
 
+ShaderProgram* ShaderProgram::sendMaterial(COMP::Material* const material,
+                                           uint32_t sampler) {
+    bind();
+
+    glUniform1d(UNILOC_MATERIAL_KD, material->kd);
+    glUniform1d(UNILOC_MATERIAL_KS, material->ks);
+    glUniform1d(UNILOC_MATERIAL_ALPHA, material->alpha);
+    glUniform3fv(UNILOC_MATERIAL_COLOR, 1, (float*)&material->color);
+    glUniform1ui(UNILOC_MATERIAL_SAMPLER, sampler);
+
+    return this;
+}
+
 void ShaderProgram::_linkShaders(std::vector<Shader*> const& shaders) {
     // Attach shaders
     for (Shader* shader : shaders)

--- a/src/shaderprogram.h
+++ b/src/shaderprogram.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "components/material.h"
 #include "components/pointlight.h"
 #include "shader.h"
 
@@ -21,6 +22,12 @@
 #define UNILOC_LIGHT_COLORS 1096
 #define UNILOC_LIGHT_RANGES 1128
 
+#define UNILOC_MATERIAL_KD 2000
+#define UNILOC_MATERIAL_KS 2001
+#define UNILOC_MATERIAL_ALPHA 2002
+#define UNILOC_MATERIAL_COLOR 2003
+#define UNILOC_MATERIAL_SAMPLER 2004
+
 // Light types
 #define LIGHT_TYPE_POINT 0
 #define LIGHT_TYPE_DIRECTIONAL 1
@@ -35,6 +42,8 @@ class ShaderProgram {
 
     ShaderProgram* sendLights(std::vector<Component*> const& lights,
                               glm::mat4 const& transformMatrix = glm::mat4{1.0});
+
+    ShaderProgram* sendMaterial(COMP::Material* const material, uint32_t sampler = 0);
 
     inline ShaderProgram* bind() {
         glUseProgram(_handle);

--- a/src/shaderprogram.h
+++ b/src/shaderprogram.h
@@ -2,6 +2,7 @@
 
 #include <vector>
 
+#include "components/pointlight.h"
 #include "shader.h"
 
 // Attribute locations
@@ -10,10 +11,30 @@
 #define ATTLOC_TEX_COORDS 2
 #define ATTLOC_COLOR 3
 
+// Uniform locations
+#define UNILOC_MODEL_VIEW_MAT 0
+#define UNILOC_PROJECTION_MAT 1
+
+#define UNILOC_NR_LIGHTS 1000  // Increments according to MAX_LIGHTS
+#define UNILOC_LIGHT_TYPES 1032
+#define UNILOC_LIGHT_POSITIONS 1064
+#define UNILOC_LIGHT_COLORS 1096
+#define UNILOC_LIGHT_RANGES 1128
+
+// Light types
+#define LIGHT_TYPE_POINT 0
+#define LIGHT_TYPE_DIRECTIONAL 1
+
+// Constants
+#define MAX_LIGHTS 32
+
 class ShaderProgram {
    public:
     ShaderProgram(std::vector<Shader*> const& shaders);
     ~ShaderProgram();
+
+    ShaderProgram* sendLights(std::vector<Component*> const& lights,
+                              glm::mat4 const& transformMatrix = glm::mat4{1.0});
 
     inline ShaderProgram* bind() {
         glUseProgram(_handle);
@@ -25,4 +46,16 @@ class ShaderProgram {
    private:
     void _linkShaders(std::vector<Shader*> const& shaders);
     GLuint _handle{0};
+
+    /* -- Lighting -- */
+
+    // General
+
+    uint32_t _lightTypes[MAX_LIGHTS];
+    glm::vec3 _lightPositions[MAX_LIGHTS];
+    glm::vec3 _lightColors[MAX_LIGHTS];
+
+    // Point lights
+
+    double _lightRanges[MAX_LIGHTS];
 };


### PR DESCRIPTION
Implemented light and material sending support for the `ShaderProgram` class.

The `Material` component was fixed so that it may be instantiated.

Closes #47 