### PR TITLE
Feat/quaternions

### DIFF
--- a/src/buttons.cpp
+++ b/src/buttons.cpp
@@ -24,4 +24,7 @@ void bindInput() {
 
     Input::initAxis(AXIS_ASCEND, 1.0);
     Input::bindKeysToAxis(AXIS_ASCEND, GLFW_KEY_SPACE, GLFW_KEY_LEFT_SHIFT);
+
+    Input::initAxis(AXIS_ROTATE, 1.0);
+    Input::bindKeysToAxis(AXIS_ROTATE, GLFW_KEY_E, GLFW_KEY_Q);
 }

--- a/src/buttons.h
+++ b/src/buttons.h
@@ -12,3 +12,4 @@
 #define AXIS_FORWARD 103
 #define AXIS_STRAFE 104
 #define AXIS_ASCEND 105
+#define AXIS_ROTATE 106

--- a/src/components/camera.h
+++ b/src/components/camera.h
@@ -29,9 +29,7 @@ class Camera : public Component {
     glm::mat4 viewMatrix() {
         Transform* t = _parent->getTransform();
         glm::mat4 m = glm::scale(glm::mat4(1.0), t->scale);
-        m = glm::rotate(m, -t->rot.z, glm::vec3(0, 0, 1));
-        m = glm::rotate(m, -t->rot.x, glm::vec3(1, 0, 0));
-        m = glm::rotate(m, -t->rot.y, glm::vec3(0, 1, 0));
+        m = glm::toMat4(glm::inverse(t->rot)) * m;
         return glm::translate(m, -t->pos);
     }
 

--- a/src/components/linkrenderer.h
+++ b/src/components/linkrenderer.h
@@ -112,10 +112,8 @@ class LinkRenderer : public Component {
         *res = glm::translate(*res, _parent->getTransform()->pos);
 
         // Rotate target to match source link
-        glm::vec3 rot = _parent->getTransform()->rot - _target->getParent()->getTransform()->rot;
-        *res = glm::rotate(*res, rot.y, glm::vec3(0, 1, 0));
-        *res = glm::rotate(*res, rot.x, glm::vec3(1, 0, 0));
-        *res = glm::rotate(*res, rot.z, glm::vec3(0, 0, 1));
+        glm::quat rot = glm::inverse(_target->getParent()->getTransform()->rot) * _parent->getTransform()->rot;
+        *res *= glm::toMat4(rot);
 
         // Centralize target room around target
         *res = glm::translate(*res, -_target->getParent()->getTransform()->pos);

--- a/src/components/playercontroller.h
+++ b/src/components/playercontroller.h
@@ -30,7 +30,8 @@ class PlayerController : public Component {
 
             // Rotate camera
             glm::vec3 euler = -glm::vec3(Input::axis(AXIS_LOOK_VERTICAL),
-                                         Input::axis(AXIS_LOOK_HORIZONTAL), 0);
+                                         Input::axis(AXIS_LOOK_HORIZONTAL),
+                                         Input::axis(AXIS_ROTATE));
             glm::quat rotDiff = glm::quat(euler * ((float)dt));
             t->rot *= rotDiff;
 

--- a/src/components/playercontroller.h
+++ b/src/components/playercontroller.h
@@ -21,21 +21,18 @@ class PlayerController : public Component {
             float strafe = Input::axis(AXIS_STRAFE) * dt;
             float ascend = Input::axis(AXIS_ASCEND) * dt;
 
-            // Compute directions
-            Transform *t = _parent->getTransform();
-            glm::mat4 m = glm::rotate(glm::mat4(1.0), t->rot.y, glm::vec3(0, 1, 0));
-            m = glm::rotate(m, t->rot.x, glm::vec3(1, 0, 0));
-            m = glm::rotate(m, t->rot.z, glm::vec3(0, 0, 1));
-
             // Translate along scaled directions
+            Transform *t = _parent->getTransform();
             glm::vec3 diff = forward * glm::vec3(0, 0, -1) +
                              strafe * glm::vec3(1, 0, 0) +
                              ascend * glm::vec3(0, 1, 0);
-            t->pos += glm::vec3(m * glm::vec4(diff, 1));
+            t->pos += glm::vec3(glm::toMat4(t->rot) * glm::vec4(diff, 1));
 
-            // Camera
-            t->rot.y -= Input::axis(AXIS_LOOK_HORIZONTAL) * dt;
-            t->rot.x -= Input::axis(AXIS_LOOK_VERTICAL) * dt;
+            // Rotate camera
+            glm::vec3 euler = -glm::vec3(Input::axis(AXIS_LOOK_VERTICAL),
+                                         Input::axis(AXIS_LOOK_HORIZONTAL), 0);
+            glm::quat rotDiff = glm::quat(euler * ((float)dt));
+            t->rot *= rotDiff;
 
         } else {
             //TODO::Fix

--- a/src/prototypes.h
+++ b/src/prototypes.h
@@ -13,10 +13,10 @@
 
 namespace PROT {
 Entity* newPlayer(double const& speed = 1.0, bool noclip = false);
-Entity* newWall(glm::vec3 const& pos, glm::vec3 const& rot,
+Entity* newWall(glm::vec3 const& pos, glm::quat const& rot,
                 double const& width, double const& height,
                 glm::vec3 const& color = glm::vec3(1, 1, 1), double const& thickness = 0.05);
 Entity* newSkybox(unsigned int id);
-Entity* newLink(glm::vec3 const& pos, glm::vec3 const& rot,
+Entity* newLink(glm::vec3 const& pos, glm::quat const& rot,
                 double const& width, double const& height);
 }  // namespace PROT

--- a/src/transform.cpp
+++ b/src/transform.cpp
@@ -2,8 +2,15 @@
 
 glm::mat4 Transform::matrix() {
     glm::mat4 m = glm::translate(glm::mat4(1.0), pos);
-    m = glm::rotate(m, rot.y, glm::vec3(0, 1, 0));
-    m = glm::rotate(m, rot.x, glm::vec3(1, 0, 0));
-    m = glm::rotate(m, rot.z, glm::vec3(0, 0, 1));
+    m = m * glm::toMat4(rot);
     return glm::scale(m, scale);
+}
+
+Transform* Transform::setEulerRot(glm::vec3 const& radians) {
+    rot = glm::quat(radians);
+    return this;
+}
+
+glm::vec3 Transform::getEulerRot() {
+    return glm::eulerAngles(rot);
 }

--- a/src/transform.h
+++ b/src/transform.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <glm/gtc/quaternion.hpp>
+#include <glm/gtx/quaternion.hpp>
 #include <glm/gtx/transform.hpp>
 #include <glm/mat4x4.hpp>
 #include <glm/vec3.hpp>
@@ -8,8 +10,11 @@ class Transform {
    public:
     glm::mat4 matrix();
 
+    Transform* setEulerRot(glm::vec3 const& radians);
+    glm::vec3 getEulerRot();
+
     /* -- Members -- */
     glm::vec3 pos{0.0};
-    glm::vec3 rot{0.0};
+    glm::quat rot{1.0, 0.0, 0.0, 0.0};
     glm::vec3 scale{1.0};
 };

--- a/src/worldcommands.hcc
+++ b/src/worldcommands.hcc
@@ -53,7 +53,7 @@ void playerFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     // Create player in current room
     ctx->player.room = ctx->currentRoom->getID();
     ctx->player.pos = args[0].asVec3();
-    ctx->player.rot = args[1].asVec3() / (180 / (float)M_PI);
+    ctx->player.rot = args[1].asEulerRotation();
     ctx->player.speed = args[2].asDouble();
     ctx->player.noclip = args[3].asBool();
 }
@@ -69,21 +69,18 @@ void wallFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     // Saturation
     double sat = 0.5;
 
-    // Rotation
-    glm::vec3 rot = args[1].asVec3() / (180 / (float)M_PI);
-
     // Create and append wall entity
     if (args.size() < 5)  // No color, nor thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), rot,
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
                                      args[2].asDouble(), args[3].asDouble()));
     else if (args.size() < 6)  // No thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), rot,
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
                                      args[2].asDouble(), args[3].asDouble(), args[4].asColor(sat)));
     else  // Color and thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), rot,
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
                                      args[2].asDouble(), args[3].asDouble(),
                                      args[4].asColor(sat), args[5].asDouble()));
 }
@@ -121,7 +118,7 @@ void objFunc(WorldContext* ctx, std::vector<Argument> const& args) {
 
     std::string meshName = args[0].asString();
     glm::vec3 pos = args[1].asVec3();
-    glm::vec3 rot = args[2].asVec3() / (180 / (float)M_PI);
+    glm::quat rot = args[2].asEulerRotation();
     glm::vec3 scale = args[3].asVec3();
 
     std::string texName = args[4].asString();
@@ -164,7 +161,7 @@ void linkFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     assertValidRoom(ctx);
 
     glm::vec3 pos = args[0].asVec3();
-    glm::vec3 rot = args[1].asVec3() / (180 / (float)M_PI);
+    glm::quat rot = args[1].asEulerRotation();
 
     double width = args[2].asDouble();
     double height = args[3].asDouble();

--- a/src/worldcommands.hcc
+++ b/src/worldcommands.hcc
@@ -53,7 +53,7 @@ void playerFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     // Create player in current room
     ctx->player.room = ctx->currentRoom->getID();
     ctx->player.pos = args[0].asVec3();
-    ctx->player.rot = args[1].asEulerRotation();
+    ctx->player.rot = args[1].asQuatFromEuler();
     ctx->player.speed = args[2].asDouble();
     ctx->player.noclip = args[3].asBool();
 }
@@ -72,15 +72,15 @@ void wallFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     // Create and append wall entity
     if (args.size() < 5)  // No color, nor thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asQuatFromEuler(),
                                      args[2].asDouble(), args[3].asDouble()));
     else if (args.size() < 6)  // No thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asQuatFromEuler(),
                                      args[2].asDouble(), args[3].asDouble(), args[4].asColor(sat)));
     else  // Color and thickness
         ctx->currentRoom->getEntity(TAG_WALLS)
-            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asEulerRotation(),
+            ->addChild(PROT::newWall(args[0].asVec3(), args[1].asQuatFromEuler(),
                                      args[2].asDouble(), args[3].asDouble(),
                                      args[4].asColor(sat), args[5].asDouble()));
 }
@@ -118,7 +118,7 @@ void objFunc(WorldContext* ctx, std::vector<Argument> const& args) {
 
     std::string meshName = args[0].asString();
     glm::vec3 pos = args[1].asVec3();
-    glm::quat rot = args[2].asEulerRotation();
+    glm::quat rot = args[2].asQuatFromEuler();
     glm::vec3 scale = args[3].asVec3();
 
     std::string texName = args[4].asString();
@@ -161,7 +161,7 @@ void linkFunc(WorldContext* ctx, std::vector<Argument> const& args) {
     assertValidRoom(ctx);
 
     glm::vec3 pos = args[0].asVec3();
-    glm::quat rot = args[1].asEulerRotation();
+    glm::quat rot = args[1].asQuatFromEuler();
 
     double width = args[2].asDouble();
     double height = args[3].asDouble();

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -60,7 +60,7 @@ glm::vec4 Argument::asVec4() const {
     return v;
 }
 
-glm::quat Argument::asEulerRotation() const {
+glm::quat Argument::asQuatFromEuler() const {
     return glm::quat(asVec3() / (180 / (float)M_PI));
 }
 

--- a/src/worldloader.cpp
+++ b/src/worldloader.cpp
@@ -60,6 +60,10 @@ glm::vec4 Argument::asVec4() const {
     return v;
 }
 
+glm::quat Argument::asEulerRotation() const {
+    return glm::quat(asVec3() / (180 / (float)M_PI));
+}
+
 void Argument::_fillVec(size_t n, float* ptr) const {
     std::string str{_RAW};
     size_t pos{0};

--- a/src/worldloader.h
+++ b/src/worldloader.h
@@ -23,7 +23,7 @@ class Argument {
     glm::vec3 asVec3() const;
     glm::vec4 asVec4() const;
 
-    glm::quat asEulerRotation() const;
+    glm::quat asQuatFromEuler() const;
 
    private:
     std::string const _RAW;

--- a/src/worldloader.h
+++ b/src/worldloader.h
@@ -23,6 +23,8 @@ class Argument {
     glm::vec3 asVec3() const;
     glm::vec4 asVec4() const;
 
+    glm::quat asEulerRotation() const;
+
    private:
     std::string const _RAW;
 
@@ -41,7 +43,7 @@ struct WorldContext {
     struct {
         RoomID room;
         glm::vec3 pos;
-        glm::vec3 rot;
+        glm::quat rot;
         double speed;
         bool noclip;
     } player;


### PR DESCRIPTION
Represent rotations in `Transform` as quaternions instead of using Euler-angles. Several changes had to be done throughout the code to cope with this change, particularly some logic related to links.

Closes #65 